### PR TITLE
Improve CMake config for Jila modules

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,8 +8,12 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Build type configuration
 option(JILA_RELEASE "Compile Lua code and don't use dev tools" OFF)
+option(JILA_AUDIO "Enable audio module" OFF)
+option(JILA_IMAGES "Enable image module" OFF)
+option(JILA_NET "Enable Net module" OFF)
+option(JILA_DATABASE "Enable database module" OFF)
 
-if(CMAKE_BUILD_TYPE EQUAL "Release")
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
     set(JILA_RELEASE ON)
 endif()
 
@@ -80,14 +84,26 @@ set(JILA_APP_DIR "${JILA_SOURCE_DIR}/app")
 
 # External dependencies
 add_subdirectory(${JILA_EXTERNAL_DIR}/SDL)
-add_subdirectory(${JILA_EXTERNAL_DIR}/SDL_Image)
-add_subdirectory(${JILA_EXTERNAL_DIR}/SDL_Mixer)
+
+if(JILA_IMAGES)
+    add_subdirectory(${JILA_EXTERNAL_DIR}/SDL_Image)
+    add_compile_definitions(JILA_IMAGES)
+endif()
+
+if(JILA_AUDIO)
+    add_subdirectory(${JILA_EXTERNAL_DIR}/SDL_Mixer)
+    add_compile_definitions(JILA_AUDIO)
+endif()
+
 add_subdirectory(${JILA_EXTERNAL_DIR}/lua_jit)
 
 # LevelDB configuration
-set(LEVELDB_BUILD_TESTS OFF)
-set(LEVELDB_BUILD_BENCHMARKS OFF)
-add_subdirectory(${JILA_EXTERNAL_DIR}/leveldb)
+if(JILA_DATABASE)
+    set(LEVELDB_BUILD_TESTS OFF)
+    set(LEVELDB_BUILD_BENCHMARKS OFF)
+    add_subdirectory(${JILA_EXTERNAL_DIR}/leveldb)
+    add_compile_definitions(JILA_DATABASE)
+endif()
 
 # EFSW (only for development builds)
 if(NOT JILA_RELEASE)
@@ -156,36 +172,62 @@ target_link_libraries(main
     PRIVATE
     $<TARGET_NAME_IF_EXISTS:SDL3::SDL3main>
     $<IF:$<TARGET_EXISTS:SDL3::SDL3>,SDL3::SDL3,SDL3::SDL3-static>
-    $<IF:$<TARGET_EXISTS:SDL3_image::SDL3_image>,SDL3_image::SDL3_image,SDL3_image::SDL3_image-static>
-    $<IF:$<TARGET_EXISTS:SDL3_mixer::SDL3_mixer>,SDL3_mixer::SDL3_mixer,SDL3_mixer::SDL3_mixer-static>
 )
+
+if(JILA_IMAGES)
+    target_link_libraries(
+        main 
+        PRIVATE
+        $<IF:$<TARGET_EXISTS:SDL3_image::SDL3_image>,SDL3_image::SDL3_image,SDL3_image::SDL3_image-static>
+    )
+endif()
+
+if(JILA_AUDIO)
+    target_link_libraries(
+        main 
+        PRIVATE
+        $<IF:$<TARGET_EXISTS:SDL3_mixer::SDL3_mixer>,SDL3_mixer::SDL3_mixer,SDL3_mixer::SDL3_mixer-static>
+    )
+endif()
 
 # FetchContent dependencies
 include(FetchContent)
 
 # Android curl configuration
-if(ANDROID)
+if(ANDROID AND JILA_NET)
     # TODO: Fix curl build for Android. SSL dont work.
     find_package(curl REQUIRED CONFIG COMPONENTS HTTP HTTPS)
     target_link_libraries(main PRIVATE curl::curl_static)
 endif()
 
-# CPR HTTP library
-FetchContent_Declare(
-    cpr
-    GIT_REPOSITORY https://github.com/libcpr/cpr.git
-    GIT_TAG 1.12.0
-)
-FetchContent_MakeAvailable(cpr)
+if(JILA_NET)
+    # CPR HTTP library
+    FetchContent_Declare(
+        cpr
+        GIT_REPOSITORY https://github.com/libcpr/cpr.git
+        GIT_TAG 1.12.0
+    )
+    FetchContent_MakeAvailable(cpr)
 
-# Final linking
+    target_link_libraries(main
+        PRIVATE
+        cpr::cpr
+    )
+    add_compile_definitions(JILA_NET)
+endif()
+
 target_link_libraries(main
     PRIVATE
     luajit::lib
     luajit::header
-    cpr::cpr
-    leveldb
 )
+
+if(JILA_DATABASE)
+    target_link_libraries(main
+        PRIVATE
+        leveldb
+    )
+endif()
 
 if(NOT JILA_RELEASE)
     target_link_libraries(main PRIVATE efsw)

--- a/src/components/components.hpp
+++ b/src/components/components.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <array>
+#include <vector>
 #include "engine/component.hpp"
 
 #include "components/engine/c_engine.hpp"
@@ -8,25 +8,33 @@
 #include "components/imgui/c_imgui.hpp"
 #include "components/threads/c_threads.hpp"
 #include "components/sdl3/c_sdl3.hpp"
+#ifdef JILA_NET
 #include "components/net/c_net.hpp"
+#endif
 #include "components/filesystem/fs.hpp"
 #include "components/font/fa_font.hpp"
 #include "components/system/c_system.hpp"
+#ifdef JILA_DATABASE
 #include "components/database/c_database.hpp"
+#endif
 
 namespace Jila {
 
-static std::array<LuaComponent, 10> components {
+static std::vector<LuaComponent> components {
     ComponentEngine,
     ComponentProperties,
     ComponentImGui,
     ComponentThreads,
     ComponentSdl,
+    #ifdef JILA_NET
     ComponentNet,
+    #endif
     ComponentFileSystem,
     ComponentFaIcons,
     ComponentSystem,
+    #ifdef JILA_DATABASE
     ComponentDataBase
+    #endif
 };
 
 }

--- a/src/components/database/c_database.cpp
+++ b/src/components/database/c_database.cpp
@@ -1,3 +1,4 @@
+#ifdef JILA_DATABASE
 #include "components/database/c_database.hpp"
 #include "misc.hpp"
 #include "leveldb/db.h"
@@ -104,3 +105,4 @@ void Quit(sol::state* state) {
 }
 
 }
+#endif

--- a/src/components/database/c_database.hpp
+++ b/src/components/database/c_database.hpp
@@ -1,3 +1,4 @@
+#ifdef JILA_DATABASE
 #pragma once
 
 #include "engine/component.hpp"
@@ -19,3 +20,4 @@ static LuaComponent ComponentDataBase {
 };
 
 }
+#endif

--- a/src/components/net/c_net.cpp
+++ b/src/components/net/c_net.cpp
@@ -1,3 +1,4 @@
+#ifdef JILA_NET
 #include "components/net/c_net.hpp"
 #include "cpr/cpr.h"
 #include "cpr/response.h"
@@ -67,3 +68,4 @@ void Quit(sol::state* state) {
 }
 
 }
+#endif

--- a/src/components/net/c_net.hpp
+++ b/src/components/net/c_net.hpp
@@ -1,3 +1,4 @@
+#ifdef JILA_NET
 #pragma once
 
 #include "engine/component.hpp"
@@ -19,3 +20,4 @@ static LuaComponent ComponentNet {
 };
 
 }
+#endif

--- a/src/components/sdl3/audio.cpp
+++ b/src/components/sdl3/audio.cpp
@@ -1,3 +1,4 @@
+#ifdef JILA_AUDIO
 #include <memory>
 #include "SDL3/SDL_properties.h"
 #include "SDL3_mixer/SDL_mixer.h"
@@ -249,3 +250,4 @@ void bindSdlAudio(sol::state* state) {
 }
 
 }
+#endif

--- a/src/components/sdl3/audio.hpp
+++ b/src/components/sdl3/audio.hpp
@@ -1,3 +1,4 @@
+#ifdef JILA_AUDIO
 #pragma once
 
 #include "sol/sol.hpp"
@@ -7,3 +8,4 @@ namespace Jila {
 void bindSdlAudio(sol::state* state);
 
 }
+#endif

--- a/src/components/sdl3/c_sdl3.cpp
+++ b/src/components/sdl3/c_sdl3.cpp
@@ -1,7 +1,11 @@
 #include "components/sdl3/c_sdl3.hpp"
+#ifdef JILA_AUDIO
 #include "components/sdl3/audio.hpp"
+#endif
 #include "components/sdl3/events.hpp"
+#ifdef JILA_IMAGES
 #include "components/sdl3/images.hpp"
+#endif
 #include "components/sdl3/window.hpp"
 #include "components/sdl3/micro.hpp"
 #include "components/sdl3/timer.hpp"
@@ -11,9 +15,13 @@ namespace Jila {
 namespace SdlComponent {
 
 bool Init(sol::state* state) {
+    #ifdef JILA_AUDIO
     bindSdlAudio(state);
+    #endif
     bindSdlEvent(state);
+    #ifdef JILA_IMAGES
     bindSdlImages(state);
+    #endif
     bindSdlWindow(state);
     bindSdlMicro(state);
     bindSdlTimer(state);

--- a/src/components/sdl3/images.cpp
+++ b/src/components/sdl3/images.cpp
@@ -1,3 +1,4 @@
+#ifdef JILA_IMAGES
 #include "components/sdl3/images.hpp"
 #include "imgui.h"
 #include "SDL3/SDL_render.h"
@@ -73,3 +74,4 @@ void bindSdlImages(sol::state* state) {
 }
 
 }
+#endif

--- a/src/components/sdl3/images.hpp
+++ b/src/components/sdl3/images.hpp
@@ -1,3 +1,4 @@
+#ifdef JILA_IMAGES
 #pragma once
 
 #include "sol/sol.hpp"
@@ -7,3 +8,4 @@ namespace Jila {
 void bindSdlImages(sol::state* state);
 
 }
+#endif


### PR DESCRIPTION
* You now able enable some modules if you need this, instead use all by default (including external modules);
* Replace array to vector for fix segfault, because array size is 10, but actual we use only 8, then 2 LuaComponent initialize with a null variables...
* Use STREQUAL instead of EQUAL;